### PR TITLE
Active by default now that we're a plugin

### DIFF
--- a/templates/ReduxPersist.js
+++ b/templates/ReduxPersist.js
@@ -3,7 +3,7 @@ import { AsyncStorage } from 'react-native'
 
 // More info here:  https://shift.infinite.red/shipping-persistant-reducers-7341691232b1
 const REDUX_PERSIST = {
-  active: false,
+  active: true,
   reducerVersion: '1.0',
   storeConfig: {
     key: 'primary',


### PR DESCRIPTION
Now that redux-persist is in a plugin we can assume we want it active if it's installed.

Closes #6